### PR TITLE
Add support for editors with additional arguments

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,5 @@ description = "Opens a user's preferred text editor so they can edit data inline
 keywords = ["editor", "cli", "text", "xvrqt"]
 categories = ["config", "text-editors", "command-line-interface"]
 
+[dependencies]
+shell-words = "1.0.0"


### PR DESCRIPTION
Hello,

First, thanks for the awesome lib and documentation :smiley: 

In my initial test, this lib was not working on my set up: Ubuntu 18, Rust 1.42 and `VISUAL="code --wait"`.

I was getting the following error, even with the simplest example:

```
Error: Failed to open `code --wait` as a text editor or editor was terminated with errors.
```

So I think I've figured out the problem: when opening the editor, `Command::new()` must be called with just the base program, it does not accept additional args. My initial reflex was to split on spaces and pass the first term to `new()` and the rest to `args()`.

However I think the editor string can use shell quotes to escape things, so getting it right myself seemed too hard. Luckily there is `shell-words` that does exactly that and it seems to do it pretty well.

Now, for my setup at least, it is working! You can test it with:

```rust
editor::new().editor("code --wait").open()?;
```

What do you think about integrating this PR?
Best regards